### PR TITLE
ENH support empty taxonomy

### DIFF
--- a/app.py
+++ b/app.py
@@ -80,11 +80,10 @@ def get_seq_filter():
     hq_only = request.form.get('hq_only', False)
     habitat = request.form.get('habitat')
     if habitat is None:
-        return {"status": "error", "msg": "Invalid habitat value"}, 400
+        habitat = ""
     taxonomy = request.form.get('taxonomy')
-    if taxonomy is not None :
-        if '__' not in taxonomy:
-            return {"status": "error", "msg": "Invalid taxonomy value"}, 400
+    if taxonomy is None:
+        taxonomy = ""
     results = seqinfo90.seq_filter(parse_bool(hq_only), habitat, taxonomy)
     return jsonify({
         "status": "Ok",


### PR DESCRIPTION
It should work for all 4 condition.
But when I modify app.py in the server, it It has not taken effect.Does it need to be restarted?

Before:
- Only search by habitat
(1)without –d taxonomy: Work 
curl -X POST -d habitat=marine -d hq_only=True https://gmsc-api.big-data-biology.org/v1/seq-filter/ 
(2)with empty –d taxonomy: Doesn’t work 【【I prefer it should work】】 curl -X POST -d habitat=marine -d taxonomy="" -d hq_only=True https://gmsc-api.big-data-biology.org/v1/seq-filter/ {"msg":"Invalid taxonomy value","status":"error"}

- Only search by taxonomy 
(1)without –d habitat: Doesn’t work
curl -X POST -d taxonomy="d__Bacteria" -d hq_only=True https://gmsc-api.big-data-biology.org/v1/seq-filter/ 
(2)with empty –d habitat: Work
curl -X POST -d habitat="" -d taxonomy="d__Bacteria" -d hq_only=True https://gmsc-api.big-data-biology.org/v1/seq-filter/